### PR TITLE
Fix superclass mismatch

### DIFF
--- a/lib/spree_promotion_roles_rule/engine.rb
+++ b/lib/spree_promotion_roles_rule/engine.rb
@@ -12,9 +12,9 @@ module SpreePromotionRolesRule
     end
 
     def self.activate
-      Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*.rb')) do |c|
-        Rails.configuration.cache_classes ? require(c) : load(c)
-      end
+	    Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
+		    Rails.configuration.cache_classes ? require(c) : load(c)
+	    end
     end
 
     config.to_prepare &method(:activate).to_proc

--- a/spree_promotion_roles_rule.gemspec
+++ b/spree_promotion_roles_rule.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_promotion_roles_rule'
-  s.version     = '2.3.0'
+  s.version     = '2.3.1'
   s.summary     = 'Promotion rule for user roles'
   s.description = 'Enables promotions to be eligible for users of a specific role.'
   s.required_ruby_version = '>= 1.9.3'


### PR DESCRIPTION
During development, extensions get re-activated when code changes are made.  Reloading base models causes (somewhat inexplicably) a superclass mismatch on the RolesPromotionRule class.  It appears most extensions only load their decorators on activate, so that's what this change is.
